### PR TITLE
feat: externalize framer-motion from bundled framer.js

### DIFF
--- a/unframer/scripts/download.ts
+++ b/unframer/scripts/download.ts
@@ -53,6 +53,8 @@ export async function main({ framerTypesUrl }) {
             'process.env.NODE_ENV': JSON.stringify('production'),
             // 'RenderEnvironment.target': JSON.stringify('PREVIEW'),
         },
+        external: ['real-framer-motion', 'framer-motion'],
+        inject: [path.resolve(__dirname, 'framer-motion-inject.js')],
         plugins: [
             esbuildPluginBundleDependencies({
                 externalizeNpm: true,

--- a/unframer/scripts/framer-motion-inject.js
+++ b/unframer/scripts/framer-motion-inject.js
@@ -1,0 +1,2 @@
+// Inject file to replace bundled framer-motion with external imports
+export * from 'real-framer-motion'


### PR DESCRIPTION
Fixes #33

This PR externalizes framer-motion from the bundled framer.js file using esbuild's inject feature.

## Changes
- Add esbuild external configuration for 'real-framer-motion' and 'framer-motion'
- Create inject file to provide framer-motion exports
- Use esbuild inject feature to replace bundled framer-motion code

This should reduce the size of framer.js by externalizing framer-motion.

Generated with [Claude Code](https://claude.ai/code)